### PR TITLE
std: implement `hostname` using `GetHostNameW` on Windows, 

### DIFF
--- a/library/std/src/net/hostname.rs
+++ b/library/std/src/net/hostname.rs
@@ -5,7 +5,18 @@ use crate::ffi::OsString;
 /// This can error out in platform-specific error cases;
 /// for example, uefi and wasm, where hostnames aren't
 /// supported.
+///
+/// # Underlying system calls
+///
+/// | Platform | System call                                                                                             |
+/// |----------|---------------------------------------------------------------------------------------------------------|
+/// | UNIX     | [`gethostname`](https://www.man7.org/linux/man-pages/man2/gethostname.2.html)                           |
+/// | Windows  | [`GetHostNameW`](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-gethostnamew) |
+///
+/// Note that platform-specific behavior [may change in the future][changes].
+///
+/// [changes]: crate::io#platform-specific-behavior
 #[unstable(feature = "gethostname", issue = "135142")]
 pub fn hostname() -> crate::io::Result<OsString> {
-    crate::sys_common::net::gethostname()
+    crate::sys::net::gethostname()
 }

--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -1978,7 +1978,7 @@ Windows.Win32.Networking.WinSock.FD_SET
 Windows.Win32.Networking.WinSock.FIONBIO
 Windows.Win32.Networking.WinSock.freeaddrinfo
 Windows.Win32.Networking.WinSock.getaddrinfo
-Windows.Win32.Networking.WinSock.gethostname
+Windows.Win32.Networking.WinSock.GetHostNameW
 Windows.Win32.Networking.WinSock.getpeername
 Windows.Win32.Networking.WinSock.getsockname
 Windows.Win32.Networking.WinSock.getsockopt

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -113,6 +113,7 @@ windows_targets::link!("ntdll.dll" "system" fn NtReadFile(filehandle : HANDLE, e
 windows_targets::link!("ntdll.dll" "system" fn NtWriteFile(filehandle : HANDLE, event : HANDLE, apcroutine : PIO_APC_ROUTINE, apccontext : *const core::ffi::c_void, iostatusblock : *mut IO_STATUS_BLOCK, buffer : *const core::ffi::c_void, length : u32, byteoffset : *const i64, key : *const u32) -> NTSTATUS);
 windows_targets::link!("ntdll.dll" "system" fn RtlNtStatusToDosError(status : NTSTATUS) -> u32);
 windows_targets::link!("userenv.dll" "system" fn GetUserProfileDirectoryW(htoken : HANDLE, lpprofiledir : PWSTR, lpcchsize : *mut u32) -> BOOL);
+windows_targets::link!("ws2_32.dll" "system" fn GetHostNameW(name : PWSTR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn WSACleanup() -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn WSADuplicateSocketW(s : SOCKET, dwprocessid : u32, lpprotocolinfo : *mut WSAPROTOCOL_INFOW) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn WSAGetLastError() -> WSA_ERROR);
@@ -126,7 +127,6 @@ windows_targets::link!("ws2_32.dll" "system" fn closesocket(s : SOCKET) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn connect(s : SOCKET, name : *const SOCKADDR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn freeaddrinfo(paddrinfo : *const ADDRINFOA));
 windows_targets::link!("ws2_32.dll" "system" fn getaddrinfo(pnodename : PCSTR, pservicename : PCSTR, phints : *const ADDRINFOA, ppresult : *mut *mut ADDRINFOA) -> i32);
-windows_targets::link!("ws2_32.dll" "system" fn gethostname(name : PSTR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getpeername(s : SOCKET, name : *mut SOCKADDR, namelen : *mut i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getsockname(s : SOCKET, name : *mut SOCKADDR, namelen : *mut i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getsockopt(s : SOCKET, level : i32, optname : i32, optval : PSTR, optlen : *mut i32) -> i32);


### PR DESCRIPTION
..and make the UNIX code resilient against bad platform behaviour.

`std`'s tests need to pass on Windows, so `hostname` must be implemented there before rust-lang/rust#135141 can be merged. I also took the opportunity to correct some of the UNIX code, `gethostname` has some very weird behaviour on some platforms, this change should make the implementation resilient against that.